### PR TITLE
URLスキームの形式修正

### DIFF
--- a/dConnectJavascriptApp/js/sdk/dconnectsdk-2.1.0.js
+++ b/dConnectJavascriptApp/js/sdk/dconnectsdk-2.1.0.js
@@ -1292,9 +1292,17 @@ var dConnect = (function(parent, global) {
     if (state === undefined) {
         state = '';
     }
-    url = uriSchemeName + '://start/' + state
-              + '?origin=' + origin
-              + '&key=' + _currentHmacKey;
+    if (isFirefox()) {
+        url = uriSchemeName + '://start/' + state
+                  + '?origin=' + origin
+                  + '&key=' + _currentHmacKey;
+    } else {
+       urlScheme.setPath('start/' + state);
+      urlScheme.addParameter('package', 'org.deviceconnect.android.manager');
+      urlScheme.addParameter('S.origin', origin);
+      urlScheme.addParameter('S.key', _currentHmacKey);
+      url = urlScheme.build();
+    }
     location.href = url;
   };
 
@@ -1342,9 +1350,17 @@ var dConnect = (function(parent, global) {
     if (state === undefined) {
         state = '';
     }
-    url = uriSchemeName + '://stop/' + state
+    if (isFirefox()) {
+        url = uriSchemeName + '://stop/' + state
               + '?origin=' + origin
               + '&key=' + _currentHmacKey;
+    } else {
+       urlScheme.setPath('stop/' + state);
+      urlScheme.addParameter('package', 'org.deviceconnect.android.manager');
+      urlScheme.addParameter('S.origin', origin);
+      urlScheme.addParameter('S.key', _currentHmacKey);
+      url = urlScheme.build();
+    }
     location.href = url;
   };
 
@@ -2150,7 +2166,7 @@ var dConnect = (function(parent, global) {
    * @return {String} URIスキームの文字列表現
    */
   AndroidURISchemeBuilder.prototype.build = function() {
-    var urlScheme = 'intent://' + this.path + '/#Intent;scheme=' +
+    var urlScheme = 'intent://' + this.path + '#Intent;scheme=' +
                             this.scheme + ';';
     for (var key in this.params) {
       urlScheme += key + '=' + this.params[key] + ';';

--- a/dConnectSDKForJavascript/dconnectsdk-2.1.0.js
+++ b/dConnectSDKForJavascript/dconnectsdk-2.1.0.js
@@ -1292,9 +1292,17 @@ var dConnect = (function(parent, global) {
     if (state === undefined) {
         state = '';
     }
-    url = uriSchemeName + '://start/' + state
-              + '?origin=' + origin
-              + '&key=' + _currentHmacKey;
+    if (isFirefox()) {
+        url = uriSchemeName + '://start/' + state
+                  + '?origin=' + origin
+                  + '&key=' + _currentHmacKey;
+    } else {
+       urlScheme.setPath('start/' + state);
+      urlScheme.addParameter('package', 'org.deviceconnect.android.manager');
+      urlScheme.addParameter('S.origin', origin);
+      urlScheme.addParameter('S.key', _currentHmacKey);
+      url = urlScheme.build();
+    }
     location.href = url;
   };
 
@@ -1342,9 +1350,17 @@ var dConnect = (function(parent, global) {
     if (state === undefined) {
         state = '';
     }
-    url = uriSchemeName + '://stop/' + state
+    if (isFirefox()) {
+        url = uriSchemeName + '://stop/' + state
               + '?origin=' + origin
               + '&key=' + _currentHmacKey;
+    } else {
+       urlScheme.setPath('stop/' + state);
+      urlScheme.addParameter('package', 'org.deviceconnect.android.manager');
+      urlScheme.addParameter('S.origin', origin);
+      urlScheme.addParameter('S.key', _currentHmacKey);
+      url = urlScheme.build();
+    }
     location.href = url;
   };
 
@@ -2150,7 +2166,7 @@ var dConnect = (function(parent, global) {
    * @return {String} URIスキームの文字列表現
    */
   AndroidURISchemeBuilder.prototype.build = function() {
-    var urlScheme = 'intent://' + this.path + '/#Intent;scheme=' +
+    var urlScheme = 'intent://' + this.path + '#Intent;scheme=' +
                             this.scheme + ';';
     for (var key in this.params) {
       urlScheme += key + '=' + this.params[key] + ';';

--- a/dConnectSDKForJavascriptTest/dconnectsdk-2.1.0.js
+++ b/dConnectSDKForJavascriptTest/dconnectsdk-2.1.0.js
@@ -1292,9 +1292,17 @@ var dConnect = (function(parent, global) {
     if (state === undefined) {
         state = '';
     }
-    url = uriSchemeName + '://start/' + state
-              + '?origin=' + origin
-              + '&key=' + _currentHmacKey;
+    if (isFirefox()) {
+        url = uriSchemeName + '://start/' + state
+                  + '?origin=' + origin
+                  + '&key=' + _currentHmacKey;
+    } else {
+       urlScheme.setPath('start/' + state);
+      urlScheme.addParameter('package', 'org.deviceconnect.android.manager');
+      urlScheme.addParameter('S.origin', origin);
+      urlScheme.addParameter('S.key', _currentHmacKey);
+      url = urlScheme.build();
+    }
     location.href = url;
   };
 
@@ -1342,9 +1350,17 @@ var dConnect = (function(parent, global) {
     if (state === undefined) {
         state = '';
     }
-    url = uriSchemeName + '://stop/' + state
+    if (isFirefox()) {
+        url = uriSchemeName + '://stop/' + state
               + '?origin=' + origin
               + '&key=' + _currentHmacKey;
+    } else {
+       urlScheme.setPath('stop/' + state);
+      urlScheme.addParameter('package', 'org.deviceconnect.android.manager');
+      urlScheme.addParameter('S.origin', origin);
+      urlScheme.addParameter('S.key', _currentHmacKey);
+      url = urlScheme.build();
+    }
     location.href = url;
   };
 
@@ -2150,7 +2166,7 @@ var dConnect = (function(parent, global) {
    * @return {String} URIスキームの文字列表現
    */
   AndroidURISchemeBuilder.prototype.build = function() {
-    var urlScheme = 'intent://' + this.path + '/#Intent;scheme=' +
+    var urlScheme = 'intent://' + this.path + '#Intent;scheme=' +
                             this.scheme + ';';
     for (var key in this.params) {
       urlScheme += key + '=' + this.params[key] + ';';


### PR DESCRIPTION
ローカルサーバなどで動作させるときは「gotapi://」でも起動したのだが、サーバなどにアップする場合は「intent://」の形式でないとアプリ起動がブロックされる問題の修正。