### PR TITLE
QUnitのタイムアウト調整

### DIFF
--- a/dConnectSDKForJavascriptTest/tests/profiles/light_normal.js
+++ b/dConnectSDKForJavascriptTest/tests/profiles/light_normal.js
@@ -91,7 +91,7 @@ LightProfileNormalTest.lightOnNormalTest001 = function(assert) {
       }
       setTimeout(function() {
         QUnit.start();
-      }, 3000);
+      }, 5000);
     } else {
       QUnit.start();
     }
@@ -137,7 +137,7 @@ LightProfileNormalTest.statusChangeNormalTest001 = function(assert) {
       }
       setTimeout(function() {
         QUnit.start();
-      }, 3000);
+      }, 5000);
     } else {
       QUnit.start();
     }

--- a/dConnectSDKForJavascriptTest/tests/profiles/notification_normal.js
+++ b/dConnectSDKForJavascriptTest/tests/profiles/notification_normal.js
@@ -307,14 +307,16 @@ NotificationProfileNormalTest.notifyNormalTest008 = function(assert) {
     builder.setAccessToken(accessToken);
     builder.addParameter(dConnect.constants.notification.PARAM_NOTIFICATION_ID, json.notificationId);
     var uri = builder.build();
-    dConnect.delete(uri, null, function(json) {
-      assert.ok(true, 'result=' + json.result);
-      QUnit.start();
-    }, function(errorCode, errorMessage) {
-      assert.ok(checkErrorCode(errorCode),
-        'errorCode=' + errorCode + ', errorMessage=' + errorMessage);
-      QUnit.start();
-    });
+    setTimeout(function() {
+		dConnect.delete(uri, null, function(json) {
+		  assert.ok(true, 'result=' + json.result);
+		  QUnit.start();
+		}, function(errorCode, errorMessage) {
+		  assert.ok(checkErrorCode(errorCode),
+			'errorCode=' + errorCode + ', errorMessage=' + errorMessage);
+		  QUnit.start();
+		});
+	}, 5000);
   }, function(errorCode, errorMessage) {
     assert.ok(checkErrorCode(errorCode),
       'errorCode=' + errorCode + ', errorMessage=' + errorMessage);


### PR DESCRIPTION
## 更新内容
* iOSのHostはNotificationが表示されるのを待たないとDELETE /notification/notifyで削除できない。
* Lightのflashingの点滅を終了する前に次のテストが実行されると失敗する。