### PR TITLE
FormDataの非サポートメソッド対策

### DIFF
--- a/dConnectJavascriptApp/js/profile/canvas.js
+++ b/dConnectJavascriptApp/js/profile/canvas.js
@@ -129,8 +129,12 @@ function doCanvasDrawImage(serviceId, fileFormId) {
   var myForm = document.getElementById(fileFormId);
   var myFormData = new FormData(myForm);
   var myXhr = new XMLHttpRequest();
-  if (!myFormData.get('mode')) {
-    myFormData.delete('mode');
+  try {
+    if (!myFormData.get('mode')) {
+      myFormData.delete('mode');
+    }
+  } catch (e) {
+    // Safariなどでは、FormData#append以外はサポートしていないため、エラーが出る
   }
   myXhr.open(myForm.method, myForm.action, true);
   myXhr.onreadystatechange = function() {


### PR DESCRIPTION
## 更新内容
* Safariブラウザなどでは、FormData#append()以外のメソッドはサポートされていないため、その対策。