### PR TITLE
不具合修正: Phone プロファイルのモード設定で非サポートエラーが返る

### DIFF
--- a/dConnectJavascriptApp/js/profile/phone.js
+++ b/dConnectJavascriptApp/js/profile/phone.js
@@ -267,12 +267,12 @@ function doPhoneCall(serviceId) {
 function doPhoneSet(serviceId) {
   let modeValue = $('#mode').val();
   body = 'mode=' + modeValue;
-  sdk.post({
+  sdk.put({
     profile: 'phone',
     attribute: 'set',
     params: {
       serviceId: serviceId,
-      mode: mode
+      mode: modeValue
     }
   }).then(json => {
     if (DEBUG) {


### PR DESCRIPTION
# 修正内容
Phone プロファイルのモード設定で非サポートエラーが返る問題を修正。原因はHTTPメソッドの違い。